### PR TITLE
Add Docker support for local development

### DIFF
--- a/client/Dockerfile.dev
+++ b/client/Dockerfile.dev
@@ -1,0 +1,23 @@
+# Use an official Node.js runtime as a parent image
+FROM node:16
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json to install dependencies
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application files to the container
+COPY . .
+
+# Expose the port the React app will run on
+EXPOSE 3000
+
+# Enable hot reload in Docker
+ENV CHOKIDAR_USEPOLLING=true
+
+# Start the React app in development mode
+CMD ["npm", "start"]

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,7 +6,7 @@ import { Container, Typography, Select, MenuItem, FormControl, InputLabel, Box, 
 
 function App() {
 
-  const apiUrl = "https://mimic-iv-to-omop-mapping-server.onrender.com";
+  const apiUrl = "http://localhost:8001"; // for loacalhost development
 
   const [tables, setTables] = useState([]);
   const [selectedTable, setSelectedTable] = useState('');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  server:
+    build:
+      context: ./server
+      dockerfile: Dockerfile.dev
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./server:/app  # Mounts server code for live reload
+    environment:
+      - PYTHONUNBUFFERED=1
+
+  client:
+    build:
+      context: ./client
+      dockerfile: Dockerfile.dev
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./client:/app  # Mounts client code for live reload
+      - /app/node_modules  # Ensures node_modules is not overwritten
+    environment:
+      - CHOKIDAR_USEPOLLING=true  # Enables hot reloading
+      - DISABLE_ESLINT_PLUGIN=true  # Disables ESLint in Create React App
+    depends_on:
+      - server

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -1,0 +1,19 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file and install dependencies
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the entire server code into the container
+COPY . .
+
+# Expose the port FastAPI will run on
+EXPOSE 8000
+
+# Start FastAPI in development mode with hot reloading
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -87,7 +87,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=[
         "https://mimic-to-omop-mapping.onrender.com",  # צד הלקוח בפרודקשן
-        "http://localhost:3000"  # צד הלקוח בסביבת הפיתוח
+        "http://localhost:3000",  # צד הלקוח בסביבת הפיתוח
+        "http://127.0.0.1:3000" # backend server in docker container
     ],
     allow_credentials=True,
     allow_methods=["GET", "POST", "OPTIONS"],


### PR DESCRIPTION
This pull request adds Docker support for local development. It includes a Dockerfile.dev for both the client and server, enabling hot-reloading in development mode. Additionally, a docker-compose.yml file is created to orchestrate the frontend and backend containers. The client/src/App.js file is updated to use the localhost API URL for local development, and the CORS settings in server/app/main.py are modified to allow requests from localhost and 127.0.0.1. ESLint is also disabled in the client Docker setup to prevent caching issues in the containerized development environment.